### PR TITLE
fix README.md links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ documents, and Ruby on Rails APIs.
 
 ## Getting started
 
-See the [/doc/usage/README.md usage]() guide to set up Megadoc for your project.
+See the [/doc/usage/README.md usage](doc/usage/README.md) guide to set up Megadoc for your project.
 
 ## Hacking
 
-See the [/doc/dev/README.md Developer's Handbook]() for extending megadoc.
+See the [/doc/dev/README.md Developer's Handbook](doc/dev/README.md) for extending megadoc.
 
 ### UI tests
 

--- a/doc/dev-cookbook/overriding-styles.md
+++ b/doc/dev-cookbook/overriding-styles.md
@@ -1,13 +1,13 @@
 # Overriding style variables
 
-The [HTMLSerializer]() provides a set of pre-defined variables that control the
-look and feel of the UI. These variables are maintained in [/ui/css/variables.less]().
+The [HTMLSerializer](/lib/HTMLSerializer.js) provides a set of pre-defined variables that control the
+look and feel of the UI. These variables are maintained in [/ui/css/variables.less](/ui/css/variables.less).
 
 In order for an override of those variables to be reflected in all stylesheets,
 we must define our overrides ahead of the compilation time.
 
 To do this, you must define a file at `[my-plugin]/ui/styleOverrides.json` 
-and register it with the [Compiler@assets compiler's asset]() registry:
+and register it with the [Compiler@assets compiler's asset](/lib/Compiler.js#L73) registry:
 
 ```javascript
 // @file: my-plugin/lib/index.js

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -6,15 +6,15 @@ unable to do anything useful beyond orchestrating plugins.
 What the core does provide is a compiler that is equipped and configured 
 with several modules your plugin can interact with:
 
-- the [Compiler@assets asset registry]() for registering static assets for serving at run-time, like images and free-form JS scripts (perhaps a Google Analytics snippet)
-- the [Compiler@linkResolver link-resolver]() for "linkifying" blocks of documentation
-- the [Compiler@renderer renderer]() for rendering Markdown to HTML
-- the [Compiler@corpus corpus]() instance for the current compilation
+- the [Compiler@assets asset registry](/lib/Compiler.js#L75) for registering static assets for serving at run-time, like images and free-form JS scripts (perhaps a Google Analytics snippet)
+- the [Compiler@linkResolver link-resolver](/lib/Compiler.js#L98) for "linkifying" blocks of documentation
+- the [Compiler@renderer renderer](/lib/Compiler.js#L108) for rendering Markdown to HTML
+- the [Compiler@corpus corpus](/lib/Compiler.js#L90) instance for the current compilation
 
 In this guide, we'll create a very basic plugin that reads Markdown files and
 presents them in the UI.
 
-Before we start, make sure you have your [./env.md local environment]() set up 
+Before we start, make sure you have your [./env.md local environment](./env.md) set up 
 and ready to start developing plugins.
 
 ## Plugin file structure
@@ -49,14 +49,14 @@ what it is:
 
 - `dist/` is optional unless you have any UI scripts, then it's mandatory. It
   contains the compiled UI scripts for your plugin which are generated using
-  [[/cli/megadoc-compile]].
+  [/cli/megadoc-compile](/cli/megadoc-compile).
 - `lib/` contains the plugin implementation files.
 - `lib/config.js` must contain all the configuration parameters your plugin accepts and they should be documented
 - `lib/index.js` is the entry point for your plugin - the one that the users will be using so it should export a function
 - `ui/` contains the plugin HTML UI implementation files.
 - `package.json` must contain a `peerDependency` on the version of megadoc you're working with
 
-For convenience, you can also clone the [megadoc-plugin-skeleton](https://github.com/megadoc/megadoc/tree/master/packages/megadoc-plugin-skeleton) 
+For convenience, you can also clone the [megadoc-plugin-skeleton](/packages/megadoc-plugin-skeleton) 
 package which has this wrapped up for you.
 
 Okay, time to get started!
@@ -64,7 +64,7 @@ Okay, time to get started!
 ## Defining a plugin
 
 The only requirement for a plugin to function is to expose a `#run` function
-that accepts a single argument; the [Compiler]() instance.
+that accepts a single argument; the [Compiler](/lib/Compiler.js) instance.
 
 ```javascript
 // @file: megadoc-plugin-markdown/lib/index.js
@@ -92,7 +92,7 @@ A compilation is basically a serial process composed of separate phases.
 ```
 
 Your plugin may hook into any of these stages using the compiler's
-[Compiler#on #on]() routine.
+[Compiler#on]() routine.
 
 ```javascript
 { // ...
@@ -114,7 +114,7 @@ documents. You'd usually use a source analyzer (like for generating an AST or
 some form of structured output from the source files your plugin covers) and 
 then _reduce_ those structures into corpus nodes.
 
-Check out the [./using-the-corpus.md]() guide for more information on 
+Check out the [./using-the-corpus.md](./using-the-corpus.md) guide for more information on 
 reduction.
 
 #### Example: a basic Markdown scanner
@@ -156,10 +156,10 @@ compiler.on('scan', function(done) {
 });
 ```
 
-The [AssetUtils]() contains a number of helpers for dealing with source files
+The [AssetUtils](/lib/AssetUtils.js) contains a number of helpers for dealing with source files
 and emitted files. The compiler has an instance of that factory configured for
 the current compilation which you can access using
-[Compiler@utils compiler.utils]().
+[Compiler@utils compiler.utils](/lib/Compiler.js#L85).
 
 Okay! Now we have scanned the markdown files the user had listed and built a 
 set of abstract representations of them for use in the Corpus. However, we 
@@ -186,9 +186,9 @@ compiler.on('render', function(md, linkify, done) {
   done();
 });
 ```
-
-The [Renderer#renderMarkdown md]() parameter will compile Markdown to HTML, 
-while [LinkResolver#linkify linkify]() will convert links to internal documents
+/Users/lwilkins/sandbox/megadoc/lib/HTMLSerializer__LinkResolver.js
+The [Renderer#renderMarkdown md](/lib/Renderer.js#L72) parameter will compile Markdown to HTML, 
+while [LinkResolver#linkify linkify](/lib/HTMLSerializer__LinkResolver.js#L96) will convert links to internal documents
 to either: Markdown (the default), assuming you will render the source into 
 HTML, or to HTML directly[1].
 
@@ -223,7 +223,7 @@ compiler.on('render', function(md, linkify, done) {
 ```
 
 Finally, it's worth noting here that the link "schemes" (i.e. the notation 
-used to define an internal link) [./defining-link-schemes.md can be customized]() to support different schemes, like a MediaWiki scheme (`\[[Object]]` or 
+used to define an internal link) [./defining-link-schemes.md can be customized](./defining-link-schemes.md) to support different schemes, like a MediaWiki scheme (`\[[Object]]` or 
 `\[[Custom Text | Object]]`).
 
 This may be necessary if you're parsing docs from an external source, maybe 
@@ -240,7 +240,7 @@ not need the source any longer.
 ### The `write` phase
 
 By this point, the corpus contains all the documents that are ready to be
-rendered by a web browser. Our [HTMLSerializer serializer]() now renders the 
+rendered by a web browser. Our [HTMLSerializer serializer](/lib/HTMLSerializer.js) now renders the 
 corpus into the output format, and we emit any assets we may require at 
 run-time.
 
@@ -262,7 +262,7 @@ We're now ready to get to the UI of our plugin - present the Markdown documents
 we've rendered as beautiful HTML.
 
 The UI of megadoc is written in [React](https://facebook.github.io/react/) and is extensible through different means which is covered extensively in
-[./building-interfaces.md]().
+[./building-interfaces.md](./building-interfaces.md).
 
 ## Where to go from here
 

--- a/doc/dev/env.md
+++ b/doc/dev/env.md
@@ -18,7 +18,7 @@ the linter, run their tests, and verify everything is OK.
 ## Plugin helper scripts
 
 Right now this is pretty crude and will hopefully get better, but see 
-[./plugin-helper-scripts.md]() for a bunch of CLI utilities for working with
+[./plugin-helper-scripts.md](./plugin-helper-scripts.md) for a bunch of CLI utilities for working with
 the core.
 
 ## The Devserver

--- a/doc/dev/using-the-corpus.md
+++ b/doc/dev/using-the-corpus.md
@@ -1,4 +1,4 @@
-# Using the [Corpus]()
+# Using the [Corpus](/lib/Corpus.js)
 
 ## Tuning the indexer
 

--- a/doc/usage/README.md
+++ b/doc/usage/README.md
@@ -43,7 +43,7 @@ to do with general output and formatter settings (e.g. HTML), while the other
 layer has to do with _plugins_ for feeding our input into Megadoc as we'll see
 later.
 
-To see what settings are available, refer to the [Config]() reference page.
+To see what settings are available, refer to the [Config](/lib/config.js) reference page.
 In our example, we have requested the docs to be emitted in the `public/docs`
 directory, relative to where we stored our `megadoc.conf.js` file.
 
@@ -78,8 +78,8 @@ For now, we'll introduce ourselves to the first type of plugins - ones
 that let us get some source files scanned and rendered. Choose from one of
 the following guides based on what kind of content you have:
 
-- [/packages/megadoc-plugin-markdown/README.md Markdown documents]()
-- [/packages/megadoc-plugin-js/README.md JavaScript source files]()
-- [/packages/megadoc-plugin-yard-api/README.md Rails APIs]()
-- [/packages/megadoc-plugin-lua/README.md Lua source files]()
+- [/packages/megadoc-plugin-markdown/README.md Markdown documents](/packages/megadoc-plugin-markdown/README.md Markdown documents)
+- [/packages/megadoc-plugin-js/README.md JavaScript source files](/packages/megadoc-plugin-js/README.md JavaScript source files)
+- [/packages/megadoc-plugin-yard-api/README.md Rails APIs](/packages/megadoc-plugin-yard-api/README.md Rails APIs)
+- [/packages/megadoc-plugin-lua/README.md Lua source files](/packages/megadoc-plugin-lua/README.md Lua source files)
 

--- a/doc/usage/linking.md
+++ b/doc/usage/linking.md
@@ -1,2 +1,2 @@
-# Linking to internal ocuments
+# Linking to internal documents
 


### PR DESCRIPTION
are these links supposed to work from github w/o the paths in the parentheses?